### PR TITLE
Improve the writeout method

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ w = writer.new({
     --
     -- the caller throws an error in the following cases:
     --
+    --   * it returned n which is neither nil nor number.
     --   * it returned n less than 0.
     --   * it returned n greater than #s.
     --   * it returned 0 with not timeout when #s > 0.

--- a/lib/writer.lua
+++ b/lib/writer.lua
@@ -188,7 +188,9 @@ function Writer:writeout(s)
     while len > 0 do
         local n, err, timeout = writer:write(s)
 
-        if n == nil or err then
+        if n ~= nil and type(n) ~= 'number' then
+            fatalf('writer:write() returned non-number value: %s', type(n))
+        elseif n == nil or err then
             -- connection closed by peer or got an error
             return nil, err
         elseif n < 0 then

--- a/test/writer_test.lua
+++ b/test/writer_test.lua
@@ -249,7 +249,7 @@ function testcase.flush()
         'hello',
     }
     err = assert.throws(w.flush, w)
-    assert.match(err, 'attempt to compare table with number')
+    assert.match(err, 'returned non-number value')
 end
 
 function testcase.writeout()


### PR DESCRIPTION
if the type of the returned n is neither nil nor number, it is better to explicitly throw an error.