### PR TITLE
Support creating reader instance from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ luarocks install bufio
 
 ## r = reader.new( src )
 
-create a new bufio.reader.
+create a new `bufio.reader` instance.
 
 ```lua
 local reader = require('bufio.reader')
@@ -53,7 +53,7 @@ r = reader.new({
 
 **Parameters**
 
-- `src:table|userdata`: `table` or `userdata` with `read` method.
+- `src:string|table|userdata`: `string` or object that has a `read` method.
 
 **Returns**
 

--- a/test/reader_test.lua
+++ b/test/reader_test.lua
@@ -25,12 +25,12 @@ function testcase.new()
         local err = assert.throws(function()
             reader.new(v)
         end)
-        assert.match(err, 'src.read must be function')
+        assert.match(err, 'src must be string or have read() method')
     end
     local err = assert.throws(function()
         reader.new()
     end)
-    assert.match(err, 'src.read must be function')
+    assert.match(err, 'src must be string or have read() method')
 end
 
 function testcase.setbufsize()
@@ -415,4 +415,20 @@ function testcase.readin()
     -- test that throws an error if n is not uint
     err = assert.throws(r.readin, r, true)
     assert.match(err, 'n must be uint')
+end
+
+function testcase.new_with_string()
+    local r = reader.new('hello world')
+
+    -- test that read from string
+    local data, err = assert(r:read(5))
+    assert.equal(data, 'hello')
+    assert.is_nil(err)
+
+    -- test that read all data
+    data = assert(r:read(20))
+    assert.equal(data, ' world')
+
+    -- test that return nil if no data
+    assert.is_nil(r:read(10))
 end


### PR DESCRIPTION
This pull request enhances the `bufio.reader` module by adding support for initializing readers with string inputs, updating documentation, and expanding test coverage. The most significant changes include modifying the reader initialization logic, updating error messages, and improving the documentation for clarity.

### Enhancements to `bufio.reader` functionality:
* [`lib/reader.lua`](diffhunk://#diff-dbf3970c64739db5d4cc592bc4d2d5e89b4725e52e2295631ad38ba55beacc33R29-L52): Updated the `Reader:init` method to support string inputs by wrapping the string in an internal reader object with a `read` method. This allows strings to be used as input sources, alongside tables and userdata.

### Documentation improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22): Clarified the description of `bufio.reader` initialization and updated the parameter type for `src` to include `string`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L22-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L56-R56)

### Test coverage expansion:
* [`test/reader_test.lua`](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286R419-R434): Added a new test case, `testcase.new_with_string`, to verify the behavior of `bufio.reader` when initialized with a string. This includes tests for reading partial data, reading all data, and handling empty input.
* [`test/reader_test.lua`](diffhunk://#diff-58ccd76dfe394f198ff26a8b4b2e65e8bdb480731493ce9afefcdb2a16862286L28-R33): Updated existing test cases to reflect the new error message, ensuring consistency with the updated functionality.