### PR TITLE
Change writer.new to use table dst as data store if no write method

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,11 @@ w = writer.new({
 
 **Parameters**
 
-- `dst:table|userdata`: object that has a `write` method.
+- `dst:table|userdata`: a `table` or object that has a `write` method.
+    - if `dst` is a `table` without `write` function, it is treated as a data store and used as follows:
+      ```lua
+      dst[#dst + 1] = s
+      ```
 
 **Returns**
 

--- a/lib/writer.lua
+++ b/lib/writer.lua
@@ -202,7 +202,7 @@ function Writer:writeout(s)
 
     local writer = self.writer
     local nwrite = 0
-    while len > 0 do
+    while true do
         local n, err, timeout = writer:write(s)
 
         if n ~= nil and type(n) ~= 'number' then
@@ -227,11 +227,10 @@ function Writer:writeout(s)
         elseif n == 0 then
             fatalf('writer:write() returned 0 with not timeout')
         end
+        -- write only part of data
         s = sub(s, n + 1)
         len = len - n
     end
-
-    return nwrite
 end
 
 return {

--- a/lib/writer.lua
+++ b/lib/writer.lua
@@ -46,12 +46,27 @@ function Writer:init(dst)
     local ok, res = pcall(function()
         return type(dst.write) == 'function'
     end)
-    if not ok or not res then
-        error('dst.write must be function', 2)
+
+    if ok then
+        if res then
+            self.writer = dst
+        elseif type(dst) == 'table' and dst.write == nil then
+            self.writer = {
+                write = function(_, s)
+                    dst[#dst + 1] = s
+                    return #s
+                end,
+            }
+        else
+            ok = false
+        end
+    end
+
+    if not ok then
+        error('dst must be table or have write() method', 2)
     end
 
     self.maxbufsize = MAX_BUFSIZE
-    self.writer = dst
     self.buf = {}
     self.bufsize = 0
     self.nflush = 0

--- a/test/writer_test.lua
+++ b/test/writer_test.lua
@@ -15,7 +15,6 @@ function testcase.new()
     for _, v in ipairs({
         true,
         0,
-        {},
         function()
         end,
         coroutine.create(function()
@@ -24,10 +23,10 @@ function testcase.new()
         local err = assert.throws(function()
             writer.new(v)
         end)
-        assert.match(err, 'dst.write must be function')
+        assert.match(err, 'dst must be table or have write() method')
     end
     local err = assert.throws(writer.new)
-    assert.match(err, 'dst.write must be function')
+    assert.match(err, 'dst must be table or have write() method')
 end
 
 function testcase.setbufsize()
@@ -369,4 +368,35 @@ function testcase.bytes_out()
     -- test that clear bytes_out counter
     assert.equal(w:bytes_out(true), 6)
     assert.equal(w:bytes_out(), 0)
+end
+
+function testcase.new_with_table()
+    -- test that create bufio.writer with a table
+    local dst = {}
+    local w = writer.new(dst)
+
+    -- test that writeout method write to table
+    local len, err = w:writeout('foo')
+    assert.equal(len, 3)
+    assert.is_nil(err)
+    assert.equal(dst, {
+        'foo',
+    })
+
+    -- test that add data to table
+    len, err = w:writeout('bar')
+    assert.equal(len, 3)
+    assert.is_nil(err)
+    assert.equal(dst, {
+        'foo',
+        'bar',
+    })
+
+    -- test that throw an error if dst.write is not a function
+    err = assert.throws(function()
+        writer.new({
+            write = 'foo',
+        })
+    end)
+    assert.match(err, 'dst must be table or have write() method')
 end


### PR DESCRIPTION
This pull request introduces enhancements to the `Writer` class to support `table` objects without a `write` method as valid destinations, along with corresponding updates to the documentation and tests. The most important changes include updates to the `Writer:init` method, adjustments to the `writeout` method, and the addition of new test cases.

### Enhancements to `Writer` class functionality:
* Updated `Writer:init` in `lib/writer.lua` to allow `table` objects without a `write` method to be treated as valid destinations by wrapping them in a custom `write` function. Improved error handling to clarify requirements for the `dst` parameter.
* Refactored `Writer:writeout` in `lib/writer.lua` to removed redundant return statements. [[1]](diffhunk://#diff-86bd56dcd06359f8a714db3156cee0f7ee6eed49b12ba1b156cbf420c1509a8bL205-R220) [[2]](diffhunk://#diff-86bd56dcd06359f8a714db3156cee0f7ee6eed49b12ba1b156cbf420c1509a8bR245-L234)

### Documentation updates:
* Updated `README.md` to clarify the behavior of the `dst` parameter when it is a `table` without a `write` method. Added an example to illustrate how data is appended to the table.

### Test suite improvements:
* Modified existing test cases in `test/writer_test.lua` to reflect the updated error message for invalid `dst` parameters. [[1]](diffhunk://#diff-12a7c4b0087c11945928fa5b3fe9d7a467345c0e7cf32a6d05db93f675832852L18) [[2]](diffhunk://#diff-12a7c4b0087c11945928fa5b3fe9d7a467345c0e7cf32a6d05db93f675832852L27-R29)
* Added a new test case `testcase.new_with_table` in `test/writer_test.lua` to verify the behavior of `Writer` when initialized with a `table` and to ensure data is correctly appended.